### PR TITLE
Allow `rstack` to capture backtrace from threads already traced by current application

### DIFF
--- a/rstack/src/imp/dw.rs
+++ b/rstack/src/imp/dw.rs
@@ -26,7 +26,7 @@ impl TracedThread {
         options: &TraceOptions,
         frames: &mut Vec<Frame>,
     ) -> Result<(), Error> {
-        dwfl.0.thread_frames(self.0, |frame| {
+        dwfl.0.thread_frames(self.id, |frame| {
             let mut is_signal = false;
             let ip = frame.pc(Some(&mut is_signal))?;
 

--- a/rstack/src/imp/unwind.rs
+++ b/rstack/src/imp/unwind.rs
@@ -18,7 +18,7 @@ impl TracedThread {
         options: &TraceOptions,
         frames: &mut Vec<Frame>,
     ) -> Result<(), Error> {
-        let state = PTraceState::new(self.0)?;
+        let state = PTraceState::new(self.id)?;
         let mut cursor = Cursor::remote(&space.0, &state)?;
 
         loop {


### PR DESCRIPTION
resolves #6 

I haven't tested it locally yet, but I would like to get some feedback.