### PR TITLE
Add support for accessing `x86_64` registers

### DIFF
--- a/unwind-sys/build.rs
+++ b/unwind-sys/build.rs
@@ -11,7 +11,7 @@ fn main() {
     let library = pkg_config::probe_library(lib).unwrap();
 
     // There were some ABI changes from 1.1 to 1.2 on x86_64
-    let mut it = library.version.split(".");
+    let mut it = library.version.split(&['.', '-'][..]);
     let major = it.next().unwrap().parse::<u32>().unwrap();
     let mut minor = it.next().unwrap().parse::<u32>().unwrap();
     // the pkg-config version is messed up in old versions and reports e.g. 1.21 for 1.2.1!

--- a/unwind/build.rs
+++ b/unwind/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 fn main() {
     let version = env::var("DEP_UNWIND_VERSION").unwrap();
-    let mut it = version.split(".");
+    let mut it = version.split(&['.', '-'][..]);
     let major = it.next().unwrap().parse::<u32>().unwrap();
     let minor = it.next().unwrap().parse::<u32>().unwrap();
     if major < 1 || (major == 1 && minor < 2) {

--- a/unwind/build.rs
+++ b/unwind/build.rs
@@ -8,4 +8,7 @@ fn main() {
     if major < 1 || (major == 1 && minor < 2) {
         println!("cargo:rustc-cfg=pre12");
     }
+    if major < 1 || (major == 1 && minor < 6) {
+        println!("cargo:rustc-cfg=pre16");
+    }
 }

--- a/unwind/src/lib.rs
+++ b/unwind/src/lib.rs
@@ -237,6 +237,7 @@ impl RegNum {
     pub const SP: RegNum = RegNum(UNW_REG_SP);
 }
 
+#[cfg(not(pre16))]
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 

--- a/unwind/src/lib.rs
+++ b/unwind/src/lib.rs
@@ -237,6 +237,9 @@ impl RegNum {
     pub const SP: RegNum = RegNum(UNW_REG_SP);
 }
 
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
+
 /// Information about a procedure.
 #[derive(Copy, Clone)]
 pub struct ProcedureInfo {

--- a/unwind/src/x86_64.rs
+++ b/unwind/src/x86_64.rs
@@ -1,0 +1,41 @@
+use crate::RegNum;
+use unwind_sys::*;
+
+impl RegNum {
+    /// An x86_64-specific identifier for the RAX register.
+    pub const RAX: RegNum = RegNum(UNW_X86_64_RAX);
+    /// An x86_64-specific identifier for the RDX register.
+    pub const RDX: RegNum = RegNum(UNW_X86_64_RDX);
+    /// An x86_64-specific identifier for the RCX register.
+    pub const RCX: RegNum = RegNum(UNW_X86_64_RCX);
+    /// An x86_64-specific identifier for the RBX register.
+    pub const RBX: RegNum = RegNum(UNW_X86_64_RBX);
+    /// An x86_64-specific identifier for the RSI register.
+    pub const RSI: RegNum = RegNum(UNW_X86_64_RSI);
+    /// An x86_64-specific identifier for the RDI register.
+    pub const RDI: RegNum = RegNum(UNW_X86_64_RDI);
+    /// An x86_64-specific identifier for the RBP register.
+    pub const RBP: RegNum = RegNum(UNW_X86_64_RBP);
+    /// An x86_64-specific identifier for the RSP register.
+    pub const RSP: RegNum = RegNum(UNW_X86_64_RSP);
+    /// An x86_64-specific identifier for the R8 register.
+    pub const R8: RegNum = RegNum(UNW_X86_64_R8);
+    /// An x86_64-specific identifier for the R9 register.
+    pub const R9: RegNum = RegNum(UNW_X86_64_R9);
+    /// An x86_64-specific identifier for the R10 register.
+    pub const R10: RegNum = RegNum(UNW_X86_64_R10);
+    /// An x86_64-specific identifier for the R11 register.
+    pub const R11: RegNum = RegNum(UNW_X86_64_R11);
+    /// An x86_64-specific identifier for the R12 register.
+    pub const R12: RegNum = RegNum(UNW_X86_64_R12);
+    /// An x86_64-specific identifier for the R13 register.
+    pub const R13: RegNum = RegNum(UNW_X86_64_R13);
+    /// An x86_64-specific identifier for the R14 register.
+    pub const R14: RegNum = RegNum(UNW_X86_64_R14);
+    /// An x86_64-specific identifier for the R15 register.
+    pub const R15: RegNum = RegNum(UNW_X86_64_R15);
+    /// An x86_64-specific identifier for the RIP register.
+    pub const RIP: RegNum = RegNum(UNW_X86_64_RIP);
+    /// An x86_64-specific identifier for the canonical frame address.
+    pub const CFA: RegNum = RegNum(UNW_X86_64_CFA);
+}

--- a/unwind/tests/test.rs
+++ b/unwind/tests/test.rs
@@ -37,6 +37,7 @@ fn local() {
 }
 
 #[test]
+#[cfg(not(pre16))]
 #[cfg(target_arch = "x86_64")]
 fn x86_64() {
     macro_rules! dump_register {

--- a/unwind/tests/test.rs
+++ b/unwind/tests/test.rs
@@ -37,6 +37,63 @@ fn local() {
 }
 
 #[test]
+#[cfg(target_arch = "x86_64")]
+fn x86_64() {
+    macro_rules! dump_register {
+        ($cursor:ident, $reg_num:expr, $reg_name:literal) => {
+            if let Ok(reg_val) = $cursor.register($reg_num) {
+                println!("{}: {:#016x}", $reg_name, reg_val);
+            } else {
+                println!("{} not stored!", $reg_name);
+            }
+        };
+    }
+
+    fn bar() {
+        get_context!(context);
+        let mut cursor = Cursor::local(context).unwrap();
+
+        loop {
+            if let Ok(procedure_name) = cursor.procedure_name() {
+                println!("{}:", procedure_name.name());
+            } else {
+                println!("unknown:")
+            }
+
+            dump_register!(cursor, RegNum::RAX, "rax");
+            dump_register!(cursor, RegNum::RDX, "rdx");
+            dump_register!(cursor, RegNum::RCX, "rcx");
+            dump_register!(cursor, RegNum::RBX, "rbx");
+            dump_register!(cursor, RegNum::RSI, "rsi");
+            dump_register!(cursor, RegNum::RDI, "rdi");
+            dump_register!(cursor, RegNum::RBP, "rbp");
+            dump_register!(cursor, RegNum::RSP, "rsp");
+            dump_register!(cursor, RegNum::R8, "r8");
+            dump_register!(cursor, RegNum::R9, "r9");
+            dump_register!(cursor, RegNum::R10, "r10");
+            dump_register!(cursor, RegNum::R11, "r11");
+            dump_register!(cursor, RegNum::R12, "r12");
+            dump_register!(cursor, RegNum::R13, "r13");
+            dump_register!(cursor, RegNum::R14, "r14");
+            dump_register!(cursor, RegNum::R15, "r15");
+            dump_register!(cursor, RegNum::RIP, "rip");
+            dump_register!(cursor, RegNum::CFA, "cfa");
+            println!();
+
+            if !cursor.step().unwrap() {
+                break;
+            }
+        }
+    }
+
+    fn foo() {
+        bar();
+    }
+
+    foo();
+}
+
+#[test]
 #[cfg(feature = "ptrace")]
 fn remote() {
     use std::io;


### PR DESCRIPTION
This PR supersedes #20, but has the same goal of adding support for accessing `x86_64` registers. This functionality requires libunwind 1.6 due to the bug described in #16, so the additional `x86_64` functionality will be enabled only when building with libunwind >= 1.6.