### PR TITLE
Added a simple unit test for testing process stack trace capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target/
+/rstack/test/capture-target/target/
 **/*.rs.bk
 Cargo.lock
 
 .vscode/
+.idea/

--- a/rstack/Cargo.toml
+++ b/rstack/Cargo.toml
@@ -23,3 +23,6 @@ log = "0.4"
 
 dw_ = { package = "dw", version = "0.2", path = "../dw", optional = true }
 unwind_ = { package = "unwind", version = "0.4", path = "../unwind", features = ["ptrace"], optional = true }
+
+[dev-dependencies]
+target-launcher = { version = "0.1.0", path = "test/target-launcher"}

--- a/rstack/src/lib.rs
+++ b/rstack/src/lib.rs
@@ -574,3 +574,19 @@ impl TracedThread {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::trace;
+    use target_launcher::CaptureTarget;
+
+    #[test]
+    fn capturing_trace_succeeds() {
+        let target = CaptureTarget::start().expect("Starting capture-target failed.");
+        let process =
+            trace(target.process_id()).expect("Capturing process trace of capture-target failed.");
+        assert_eq!(process.id, target.process_id());
+        assert!(process.threads().len() > 0);
+        target.stop().expect("Stopping capture-target failed.");
+    }
+}

--- a/rstack/test/capture-target/Cargo.toml
+++ b/rstack/test/capture-target/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "capture-target"
+version = "0.1.0"
+authors = ["Juha Lepola <juha.lepola@gmail.com>"]
+edition = "2018"
+description = "Simple helper process for testing the rstack."
+license = "MIT/Apache-2.0"
+repository = "https://github.com/sfackler/rstack"
+
+# Ensure debug info is always present to provide readable callstacks when capturing.
+[profile.release]
+debug = true
+
+# Workaround for the cargo issue #6745. See https://github.com/rust-lang/cargo/issues/6745#issuecomment-472667516
+[workspace]

--- a/rstack/test/capture-target/src/main.rs
+++ b/rstack/test/capture-target/src/main.rs
@@ -1,0 +1,8 @@
+use std::time::Duration;
+
+fn main() {
+    // Keep running until target-launcher forcibly kills this process.
+    loop {
+        std::thread::sleep(Duration::from_secs(1));
+    }
+}

--- a/rstack/test/target-launcher/Cargo.toml
+++ b/rstack/test/target-launcher/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "target-launcher"
+version = "0.1.0"
+authors = ["Juha Lepola <juha.lepola@gmail.com>"]
+edition = "2018"
+description = "Utility for running helper process for testing the rstack."
+license = "MIT/Apache-2.0"
+repository = "https://github.com/sfackler/rstack"
+
+[build-dependencies]
+escargot = "0.5.8"

--- a/rstack/test/target-launcher/build.rs
+++ b/rstack/test/target-launcher/build.rs
@@ -1,0 +1,35 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    // Compile the "capture-target" executable as part of the build process of this library to gain path to its location.
+    // This location is then fed to the library as part of the build process of this library so that the library
+    // can start the "capture-target" process upon request.
+
+    let out_dir = std::env::var("OUT_DIR").expect("Output directory unavailable.");
+    let run = escargot::CargoBuild::new()
+        .current_release()
+        .current_target()
+        .manifest_path("../capture-target/Cargo.toml")
+        .target_dir(&out_dir)
+        .run()
+        .expect("Compiling capture-target failed.");
+
+    let target_template = r#"
+    fn get_path() -> &'static str {
+        "PATH"
+    }
+    "#;
+    let target_template = target_template.replace(
+        "PATH",
+        run.path().to_str().expect("Unexpected characters in path."),
+    );
+
+    let dest_path = Path::new(&out_dir).join("target.rs");
+    let mut f = File::create(dest_path).expect("Opening target.rs failed.");
+    f.write_all(target_template.as_bytes())
+        .expect("Writing child.rs failed.");
+
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/rstack/test/target-launcher/src/lib.rs
+++ b/rstack/test/target-launcher/src/lib.rs
@@ -1,0 +1,53 @@
+//! Unit testing aid for the rstack library.
+//!
+//! Provides launcher for a dummy child process which stack can be captured.
+use std::io;
+use std::process::{Child, Command, Stdio};
+
+include!(concat!(env!("OUT_DIR"), "/target.rs"));
+
+pub struct CaptureTarget {
+    process: Child,
+}
+
+impl CaptureTarget {
+    /// Starts new capture target process.
+    pub fn start() -> std::io::Result<Self> {
+        let child = Command::new(get_path())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        Ok(Self { process: child })
+    }
+
+    /// Stops the capture-target process.
+    pub fn stop(mut self) -> io::Result<()> {
+        self.process.kill()?;
+        let _ = self.process.try_wait()?;
+        Ok(())
+    }
+
+    pub fn process_id(&self) -> u32 {
+        self.process.id()
+    }
+}
+
+impl Drop for CaptureTarget {
+    fn drop(&mut self) {
+        let _ = self.process.kill();
+        let _ = self.process.try_wait();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starting_and_stopping_target_succeeds() {
+        let target = CaptureTarget::start().expect("Starting capture-target failed.");
+        assert!(target.process_id() > 0);
+        target.stop().expect("Stopping capture-target failed.");
+    }
+}


### PR DESCRIPTION
I'm adding support to [proxide](https://github.com/Rantanen/proxide/) proxy for capturing the stack traces of the client process that makes requests through the proxy when the client process and the proxide proxy reside on the same host. I have already implemented a preliminary support here: https://github.com/Rantanen/proxide/pull/36. 

However, the current approach is a bit inefficient as it always captures the stack traces of all the threads of the client process even though only the stack trace of the thread associated with the request being proxy-ed is enough. Thus I  want to add support for capturing stack traces of individual threads at a time to rstack.

To do this, I wanted to start this by adding support for unit testing as I like to execute code during development time with unit tests. => This merge request.

My current plan for adding the support for capturing individual threads is to create a struct call ProcessAttachment which would have a method for capturing stack traces of individual threads. The ProcessAttachment struct would be created by calling a new method called "attach" which would be added to the TraceOptions struct. 

Does this plan/idea sound reasonable to you?
